### PR TITLE
docs(spec): Create initial spec for agentic data mesh demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# agents-running-a-data-mesh-demo
+# Agentic Data Mesh Demo: Initial Specification
+
+## High-Level Goal
+
+This document outlines the initial specification for a demo showcasing autonomous agents that can transform a raw, stream-based data environment into a product-oriented, discoverable data mesh. The primary goal of this initial phase is to align on the plan and gather feedback before implementation begins.
+
+## Phase 1: Foundational Setup & Specification (This PR)
+
+### Objective
+
+The objective of this first pull request is to submit this high-level plan and specification for community/stakeholder feedback.
+
+### The Contextual Environment
+
+The foundation of the demo is a "contextual environment" representing a typical state of raw, siloed data streams within an organization.
+
+*   **Platform:** Confluent Cloud
+*   **Data Source:** Standard Confluent sample data topics.
+*   **Initial Topics:**
+    *   `users`
+    *   `orders`
+    *   `products`
+
+These topics will serve as the initial, unstructured data sources that the agents will work with.
+
+### The Agentic Workflow (High-Level)
+
+The core of the demo is to observe agents performing the following workflow autonomously:
+
+1.  **Discovery & Ingestion:** Agents will be configured to connect to the specified Confluent topics and begin ingesting the data streams.
+
+2.  **Analysis & Enrichment:** Agents will analyze the raw data to understand its structure, content, and relationships. To enrich this analysis, they will leverage external tools and metadata sources, such as:
+    *   **Schema Registry:** To understand the formal structure of the data.
+    *   **Usage Metrics:** To identify which data is frequently used or critical.
+
+3.  **Data Product Definition:** Based on their analysis, the agents will autonomously define and register new data products. This process involves:
+    *   Identifying bounded contexts and potential data product boundaries (e.g., a "User Profile" data product from the `users` topic).
+    *   Generating the necessary configurations (e.g., Terraform files, data catalog entries) to formally define the data product, its schema, ownership, and access policies.
+
+## Future Phases (High-Level)
+
+*   Implementation of the agents themselves.
+*   Development of the Terraform configurations that the agents will generate and manage.
+*   Creation of the final presentation and a self-guided version of the demo.


### PR DESCRIPTION
Outlines the high-level plan for the agentic data mesh demo, including the contextual environment (Confluent topics) and the high-level agent workflow (discover, analyze, define).

This initial document is intended to be the basis for a PR to gather feedback before implementation begins.