### PR TITLE
Add webhook endpoint for automated slide building

### DIFF
--- a/.github/workflows/build-slides.yml
+++ b/.github/workflows/build-slides.yml
@@ -46,15 +46,22 @@ jobs:
           cd slides-src
           clasp push --force
 
-      # 7. Run the buildPresentation function
-      - name: Build presentation
+      # 7. Trigger presentation rebuild via webhook
+      - name: Trigger presentation rebuild
         run: |
-          cd slides-src
-          clasp run buildPresentation
-        continue-on-error: true
+          RESPONSE=$(curl -s -X POST "${{ secrets.SLIDES_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d '{"secret":"${{ secrets.SLIDES_WEBHOOK_SECRET }}"}')
 
-      # 8. Output success message
-      - name: Output result
-        run: |
-          echo "✅ Slide build completed!"
-          echo "Check your Google Drive for the updated presentation"
+          echo "Webhook response: $RESPONSE"
+
+          # Check if successful
+          if echo "$RESPONSE" | grep -q '"success":true'; then
+            echo "✅ Presentation rebuilt successfully!"
+            PRES_URL=$(echo "$RESPONSE" | grep -o '"presentationUrl":"[^"]*"' | cut -d'"' -f4)
+            echo "View at: $PRES_URL"
+          else
+            echo "❌ Presentation build failed"
+            echo "$RESPONSE"
+            exit 1
+          fi

--- a/slides-src/CLAUDE.md
+++ b/slides-src/CLAUDE.md
@@ -36,14 +36,26 @@ clasp logs
 
 ## Automated Builds
 
-GitHub Actions automatically builds the presentation on every push to `main`. The workflow:
-1. Pushes Apps Script code to Google
-2. Runs `buildPresentation` function
-3. Generates new presentation in Google Drive
+GitHub Actions automatically builds the presentation on every push to `main` via a webhook endpoint.
 
-**Required GitHub Secrets**:
+### How it works:
+1. GitHub Actions pushes code to Apps Script with `clasp push`
+2. GitHub Actions POSTs to the deployed web app endpoint
+3. Web app validates secret token and triggers `buildPresentation()`
+4. New presentation is generated in Google Drive
+
+### Setup Requirements:
+
+**Apps Script Deployment**:
+1. Deploy the script as a Web App (Deploy → New deployment → Web app)
+2. Set "Execute as: Me" and "Who has access: Anyone"
+3. Add `WEBHOOK_SECRET` to Script Properties with a random token
+
+**GitHub Secrets**:
 - `CLASPRC_JSON`: Contents of `~/.clasprc.json` (clasp credentials)
 - `CLASP_JSON`: Contents of `slides-src/.clasp.json` (Apps Script project ID)
+- `SLIDES_WEBHOOK_URL`: The deployed web app URL
+- `SLIDES_WEBHOOK_SECRET`: Same value as the Script Property
 
 ## Code Structure
 

--- a/slides-src/README.md
+++ b/slides-src/README.md
@@ -53,13 +53,22 @@ This will create a `.clasp.json` file with your script ID.
 clasp push
 ```
 
-### 6. Run the presentation builder
+### 6. Deploy as Web App (for GitHub Actions automation)
 
-```bash
-clasp run buildPresentation
-```
+1. Go to https://script.google.com and open your project
+2. Click **Deploy** → **New deployment**
+3. Select type: **Web app**
+4. Configure:
+   - Execute as: **Me**
+   - Who has access: **Anyone**
+5. Click **Deploy**
+6. Copy the **Web app URL**
+7. In the Apps Script editor: **File** → **Project properties** → **Script properties**
+8. Add property: `WEBHOOK_SECRET` with a random token value (generate with `openssl rand -hex 32`)
 
-Or run it from the Apps Script web editor:
+### 7. Run the presentation builder
+
+From the Apps Script web editor:
 1. Go to https://script.google.com
 2. Open your project
 3. Select `buildPresentation` from the function dropdown
@@ -67,28 +76,34 @@ Or run it from the Apps Script web editor:
 
 ## GitHub Actions Setup
 
-To automate slide generation on every push:
+To automate slide generation on every push to `main`:
 
-### 1. Get your clasp credentials
+### 1. Set up the Web App (see step 6 above)
+
+Make sure you've deployed the Apps Script as a web app and configured the `WEBHOOK_SECRET` in Script Properties.
+
+### 2. Get your clasp credentials
 
 After running `clasp login`, find the `.clasprc.json` file:
 - **Windows**: `C:\Users\YourUser\.clasprc.json`
 - **Mac/Linux**: `~/.clasprc.json`
 
-### 2. Create GitHub Secrets
+### 3. Create GitHub Secrets
 
 In your GitHub repository:
 1. Go to **Settings → Secrets and variables → Actions**
-2. Create two secrets:
+2. Create these secrets:
    - `CLASPRC_JSON`: Paste the entire contents of `.clasprc.json`
-   - `CLASP_JSON`: Paste the contents of `.clasp.json` from the `slides-src` directory
+   - `CLASP_JSON`: Paste the contents of `slides-src/.clasp.json`
+   - `SLIDES_WEBHOOK_URL`: The web app URL from deployment (step 6.6)
+   - `SLIDES_WEBHOOK_SECRET`: The same secret token from Script Properties (step 6.8)
 
-### 3. Push to main
+### 4. Push to main
 
 The workflow in `.github/workflows/build-slides.yml` will automatically:
-- Push your Apps Script code
-- Run the `buildPresentation` function
-- Generate a new presentation in your Google Drive
+1. Push your Apps Script code to Google
+2. Call the web app endpoint to trigger `buildPresentation`
+3. Generate a new presentation in your Google Drive
 
 ## Local Development
 


### PR DESCRIPTION
## Summary

Replaces the broken `clasp run` automation with a webhook-based approach that actually works in CI.

## Changes

- **Added `doPost()` webhook endpoint** in `slides-src/Code.js`
  - Validates secret token for security
  - Triggers `buildPresentation()` when called
  - Returns JSON response with presentation URL
  
- **Updated GitHub Actions workflow** to call webhook instead of `clasp run`
  - Pushes code with `clasp push` (still works)
  - POSTs to webhook URL to trigger rebuild
  - Parses response and displays presentation URL

- **Updated documentation** with deployment instructions
  - How to deploy as web app
  - Setting up Script Properties
  - Required GitHub Secrets

## Setup Required

After merging, you'll need to:

1. **Push code**: `cd slides-src && clasp push`
2. **Deploy as web app** at script.google.com
3. **Add Script Property**: `WEBHOOK_SECRET` with random token
4. **Add GitHub Secrets**: `SLIDES_WEBHOOK_URL` and `SLIDES_WEBHOOK_SECRET`

See `slides-src/README.md` for detailed steps.

## Why This Approach?

`clasp run` doesn't work in CI due to OAuth/deployment limitations. A webhook endpoint:
- ✅ Works in automated environments
- ✅ Secure with token authentication  
- ✅ Returns actionable response
- ✅ No expiring tokens to refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>