### PR TITLE
Fix webhook redirect: Add -L flag to curl

### DIFF
--- a/.github/workflows/build-slides.yml
+++ b/.github/workflows/build-slides.yml
@@ -49,7 +49,7 @@ jobs:
       # 7. Trigger presentation rebuild via webhook
       - name: Trigger presentation rebuild
         run: |
-          RESPONSE=$(curl -s -X POST "${{ secrets.SLIDES_WEBHOOK_URL }}" \
+          RESPONSE=$(curl -s -L -X POST "${{ secrets.SLIDES_WEBHOOK_URL }}" \
             -H "Content-Type: application/json" \
             -d '{"secret":"${{ secrets.SLIDES_WEBHOOK_SECRET }}"}')
 


### PR DESCRIPTION
## Issue

The webhook call was failing because Apps Script web apps redirect to their execution URL, and curl wasn't following the redirect.

## Fix

Add `-L` flag to curl command to follow HTTP redirects.

### Before:
```bash
curl -s -X POST "$WEBHOOK_URL"
```

### After:
```bash
curl -s -L -X POST "$WEBHOOK_URL"
```

## Testing

Merge this and re-run the workflow - it should now successfully call the webhook and rebuild slides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>