### PR TITLE
feat: add AWS Bedrock support for Claude API

### DIFF
--- a/agents/.env.example
+++ b/agents/.env.example
@@ -28,11 +28,35 @@ SCHEMA_REGISTRY_API_KEY=YOUR_SCHEMA_REGISTRY_API_KEY_HERE
 SCHEMA_REGISTRY_API_SECRET=YOUR_SCHEMA_REGISTRY_API_SECRET_HERE
 
 # ============================================================================
-# Claude API
+# Claude API Configuration
 # ============================================================================
-# Get from: https://console.anthropic.com/
 # Used by: Agents for LLM-powered analysis and decisions
+# Two backend options: Anthropic Direct API or AWS Bedrock
+
+# Backend Selection: 'anthropic' or 'bedrock'
+CLAUDE_BACKEND=anthropic
+
+# --- Option 1: Anthropic Direct API (when CLAUDE_BACKEND=anthropic) ---
+# Get API key from: https://console.anthropic.com/settings/keys
 ANTHROPIC_API_KEY=sk-ant-api03-YOUR_KEY_HERE
+
+# --- Option 2: AWS Bedrock (when CLAUDE_BACKEND=bedrock) ---
+# Prerequisites:
+# 1. Enable model access: AWS Bedrock Console → Model access →
+#    Request access to "Anthropic Claude 3.5 Sonnet v2"
+# 2. Create API key: AWS Bedrock Console → API Keys → Create API key
+
+# AWS region where Bedrock is enabled (us-east-1, us-west-2, eu-west-1, etc.)
+AWS_REGION=us-east-1
+
+# Bedrock API Key (paste the full value from AWS Console as-is)
+# Format: ABSKQmVkcm9ja0FQSUtleS0... (long base64-encoded string)
+BEDROCK_API_KEY=your-bedrock-api-key-here
+
+# Alternative Bedrock auth: Use AWS Access Keys instead of BEDROCK_API_KEY
+# (Uncomment if using IAM user credentials instead of Bedrock API keys)
+# AWS_ACCESS_KEY_ID=AKIA...
+# AWS_SECRET_ACCESS_KEY=...
 
 # ============================================================================
 # Optional: Cluster/Environment IDs

--- a/agents/README.md
+++ b/agents/README.md
@@ -47,8 +47,14 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 # 2. Install Python dependencies (includes anthropic, confluent-kafka, etc.)
 pip install -r requirements.txt
 
-# 3. Set your Anthropic API key (only requirement for dry-run)
+# 3. Set your Claude API credentials (only requirement for dry-run)
+# Option A: Anthropic Direct API
 export ANTHROPIC_API_KEY="sk-ant-api03-your-key-here"
+
+# Option B: AWS Bedrock
+export CLAUDE_BACKEND=bedrock
+export AWS_REGION=us-east-1
+export BEDROCK_API_KEY="your-base64-encoded-key"
 
 # 4. Run the bootstrap in dry-run mode
 python bootstrap.py --dry-run
@@ -106,8 +112,15 @@ SCHEMA_REGISTRY_API_SECRET=YOUR_SR_API_SECRET
 CONFLUENT_CLOUD_API_KEY=YOUR_CLOUD_API_KEY
 CONFLUENT_CLOUD_API_SECRET=YOUR_CLOUD_API_SECRET
 
-# Claude API
+# Claude API - Choose one of two options:
+# Option A: Anthropic Direct API
+CLAUDE_BACKEND=anthropic
 ANTHROPIC_API_KEY=sk-ant-api03-xxxxx
+
+# Option B: AWS Bedrock
+CLAUDE_BACKEND=bedrock
+AWS_REGION=us-east-1
+BEDROCK_API_KEY=your-base64-encoded-key
 ```
 
 **Get credentials from Terraform:**
@@ -310,8 +323,20 @@ Get your API key from: https://console.anthropic.com/settings/keys
 - Try dry-run mode to test without Kafka: `python bootstrap.py --dry-run`
 
 ### Claude API Fails
+
+**Using Anthropic Direct API:**
 - Check `ANTHROPIC_API_KEY` is valid
 - Verify API quota/billing at https://console.anthropic.com/
+- Ensure `CLAUDE_BACKEND=anthropic` in .env
+
+**Using AWS Bedrock:**
+- Verify model access enabled: AWS Bedrock Console → Model access → Check "Anthropic Claude 3.5 Sonnet v2" is granted
+- Check `BEDROCK_API_KEY` is correctly base64 encoded
+- Verify `AWS_REGION` matches where Bedrock is enabled (us-east-1, us-west-2, etc.)
+- Test AWS credentials: `aws bedrock list-foundation-models --region us-east-1` (if using AWS CLI)
+- Ensure `CLAUDE_BACKEND=bedrock` in .env
+
+**General:**
 - Fallback synthesis will be used if Claude fails (basic summary)
 
 ## Cost Considerations

--- a/agents/requirements.txt
+++ b/agents/requirements.txt
@@ -11,7 +11,8 @@ mcp>=1.19.0
 anthropic>=0.71.0
 
 # AWS Bedrock Runtime for Claude (alternative to Anthropic API)
-boto3>=1.35.80
+# Requires >=1.39.0 for AWS_BEARER_TOKEN_BEDROCK support (Bedrock API keys)
+boto3>=1.39.0
 
 # Additional utilities
 python-dotenv>=1.0.1


### PR DESCRIPTION
## Summary

Enable agents to use AWS Bedrock as an alternative to Anthropic's direct API, supporting the new Bedrock API key authentication method. This allows deployment in AWS environments with centralized billing and potentially lower costs.

## Key Changes

- **Bedrock API Key Support**: Added `AWS_BEARER_TOKEN_BEDROCK` authentication via `BEDROCK_API_KEY` environment variable
- **Latest Claude Models**: Support for Sonnet 4.5, Sonnet 4, 3.7 Sonnet, Opus 4.1, Opus 4, plus all 3.5 models
- **Auto-Detection**: Automatically detects API key vs IAM authentication and uses appropriate model IDs
- **Inference Profiles**: Uses cross-region inference profiles for API key auth
- **Boto3 Upgrade**: Updated to >=1.39.0 (required for bearer token support)
- **Environment Validation**: Added backend-specific credential checks in bootstrap
- **Documentation**: Comprehensive setup and troubleshooting instructions

## Files Modified

- `agents/common/claude_utils.py` - Core Bedrock integration with model mapping
- `agents/bootstrap.py` - Environment loading and validation
- `agents/.env.example` - Configuration examples for both backends
- `agents/README.md` - Setup instructions and troubleshooting
- `agents/requirements.txt` - Boto3 version requirement

## Test Plan

- [x] Tested with dry-run mode using Bedrock API key in us-east-1
- [x] Verified Claude Sonnet 4.5 synthesis works correctly
- [x] Validated environment variable detection for both backends
- [x] Confirmed inference profile routing for API key auth
- [x] Tested automatic dotenv loading

## Usage

**To use Bedrock**, set in `.env`:
```bash
CLAUDE_BACKEND=bedrock
AWS_REGION=us-east-1
BEDROCK_API_KEY=your-api-key-here
```

**To use Anthropic Direct API**, set in `.env`:
```bash
CLAUDE_BACKEND=anthropic
ANTHROPIC_API_KEY=sk-ant-api03-...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)