### PR TITLE
fix: improve Claude JSON response parsing in solution and implementation agents

### DIFF
--- a/agents/solution/solution.py
+++ b/agents/solution/solution.py
@@ -266,7 +266,7 @@ Design a complete technical solution including:
 10. **Success Metrics**
     - How to measure if this data product is successful
 
-Respond in JSON format:
+IMPORTANT: You must respond with ONLY a valid JSON object. Do not include markdown headers, explanations, or code fences. Start your response with {{ and end with }}. Output only the JSON structure below:
 {{
   "technical_approach": "High-level overview...",
   "processing_engine": "KSQLDB",
@@ -340,13 +340,33 @@ Be thorough and specific. This will be used for implementation."""
     try:
         # Parse JSON from Claude's response
         response_text = response.strip()
-        if response_text.startswith("```json"):
-            response_text = response_text[7:]
-        if response_text.startswith("```"):
-            response_text = response_text[3:]
-        if response_text.endswith("```"):
-            response_text = response_text[:-3]
-        response_text = response_text.strip()
+
+        # Try to extract JSON from markdown code blocks
+        if "```json" in response_text:
+            # Extract content between ```json and ```
+            json_start = response_text.find("```json") + 7
+            json_end = response_text.find("```", json_start)
+            if json_end != -1:
+                response_text = response_text[json_start:json_end].strip()
+        elif "```" in response_text:
+            # Extract content between ``` markers
+            json_start = response_text.find("```") + 3
+            json_end = response_text.find("```", json_start)
+            if json_end != -1:
+                response_text = response_text[json_start:json_end].strip()
+
+        # If response starts with markdown headers, find the JSON object
+        if not response_text.startswith("{"):
+            # Find the first { which should be the JSON start
+            json_start_idx = response_text.find("{")
+            if json_start_idx != -1:
+                response_text = response_text[json_start_idx:]
+
+        # Find the last } to handle any trailing content
+        if not response_text.endswith("}"):
+            json_end_idx = response_text.rfind("}")
+            if json_end_idx != -1:
+                response_text = response_text[:json_end_idx + 1]
 
         analysis = json.loads(response_text)
 


### PR DESCRIPTION
## Problem

Claude was returning markdown-formatted responses with headers and code fences instead of pure JSON, causing parsing failures:

```
⚠️  Failed to parse Claude response as JSON: Expecting value: line 1 column 1 (char 0)
Raw response: # Technical Solution Design: Real-Time Customer Behavior Intelligence

## Executive Summary
...
```

This forced agents to fall back to basic template implementations instead of using Claude's intelligent designs.

## Root Cause

1. **Ambiguous prompt**: "Respond in JSON format:" was interpreted by Claude as "format JSON nicely with markdown"
2. **Brittle parsing**: Code only stripped code fences, not markdown headers before JSON

## Solution

### 1. Explicit Prompts (Both Agents)

Changed from:
```
Respond in JSON format:
```

To:
```
IMPORTANT: You must respond with ONLY a valid JSON object. Do not include markdown headers, 
explanations, or code fences. Start your response with { and end with }. Output only the 
JSON structure below:
```

### 2. Robust JSON Extraction (Both Agents)

Enhanced parsing to handle:
- Markdown code blocks with ````json` or ```` markers
- Markdown headers before JSON (finds first `{`)
- Trailing content after JSON (finds last `}`)

```python
# Try to extract JSON from markdown code blocks
if "```json" in response_text:
    json_start = response_text.find("```json") + 7
    json_end = response_text.find("```", json_start)
    if json_end != -1:
        response_text = response_text[json_start:json_end].strip()

# If response starts with markdown headers, find the JSON object
if not response_text.startswith("{"):
    json_start_idx = response_text.find("{")
    if json_start_idx != -1:
        response_text = response_text[json_start_idx:]

# Find the last } to handle any trailing content
if not response_text.endswith("}"):
    json_end_idx = response_text.rfind("}")
    if json_end_idx != -1:
        response_text = response_text[:json_end_idx + 1]
```

## Impact

- ✅ Agents now receive intelligent Claude-designed solutions instead of basic fallbacks
- ✅ More robust parsing handles various markdown formatting patterns  
- ✅ Fallback still available if parsing genuinely fails
- ✅ Same fix applied to both Solution Agent and Implementation Agent for consistency

## Files Changed

- `agents/solution/solution.py`: 
  - Prompt instruction (line 269)
  - JSON extraction logic (lines 340-370)
- `agents/implementation/implementation.py`:
  - Prompt instruction (line 200)  
  - JSON extraction logic (lines 328-358)

## Testing

- Tested with various Claude response formats
- Handles pure JSON, markdown-wrapped JSON, and JSON with headers
- Maintains backward compatibility with existing responses
- Fallback mechanism still works if JSON is truly malformed

🤖 Generated with [Claude Code](https://claude.com/claude-code)