### PR TITLE
fix: limit all agents to process one message in interactive/demo mode

### DIFF
--- a/agents/bootstrap.py
+++ b/agents/bootstrap.py
@@ -258,7 +258,7 @@ async def run_bootstrap(dry_run=False, include_learning=False, include_evaluatio
             # Step 9/10: Decision Agent
             print_step(9, "Decision Agent (Shark Tank Panel)")
             start_time = time.time()
-            decision_result = run_decision_agent(dry_run=dry_run)
+            decision_result = run_decision_agent(dry_run=dry_run, limit_one=interactive)
             print(f"\n⏱️  Decision Agent completed in {time.time() - start_time:.2f}s")
 
             if pause_between_steps:
@@ -296,7 +296,7 @@ async def run_bootstrap(dry_run=False, include_learning=False, include_evaluatio
             # Step 10/11: Solution Agent
             print_step(10, "Solution Agent (Technical Design)")
             start_time = time.time()
-            solution_result = run_solution_agent(dry_run=dry_run, use_claude=True)
+            solution_result = run_solution_agent(dry_run=dry_run, use_claude=True, limit_one=interactive)
             print(f"\n⏱️  Solution Agent completed in {time.time() - start_time:.2f}s")
 
             if pause_between_steps:
@@ -328,7 +328,7 @@ async def run_bootstrap(dry_run=False, include_learning=False, include_evaluatio
 
                 print_step(11 if not interactive else 12, "Implementation Agent (Code Generation)")
                 start_time = time.time()
-                implementation_result = run_implementation_agent(dry_run=dry_run, use_claude=True)
+                implementation_result = run_implementation_agent(dry_run=dry_run, use_claude=True, limit_one=interactive)
                 print(f"\n⏱️  Implementation Agent completed in {time.time() - start_time:.2f}s")
 
                 if pause_between_steps:

--- a/agents/evaluation/decision.py
+++ b/agents/evaluation/decision.py
@@ -381,8 +381,13 @@ def publish_decision(decision, dry_run=False):
     return success
 
 
-def run_decision_agent(dry_run=False):
-    """Main decision agent execution."""
+def run_decision_agent(dry_run=False, limit_one=False):
+    """Main decision agent execution.
+
+    Args:
+        dry_run: If True, read from/write to files instead of Kafka
+        limit_one: If True, only process one idea (for demo/interactive mode)
+    """
     print("\n" + "=" * 60)
     print("DECISION AGENT - Shark Tank Panel Decision")
     print("=" * 60)
@@ -395,7 +400,12 @@ def run_decision_agent(dry_run=False):
             print("\n⚠️  No challenges found to synthesize")
             return []
 
-        print(f"\n1. Synthesizing decisions for {len(idea_ids)} ideas...")
+        # Limit to one if requested
+        if limit_one and len(idea_ids) > 1:
+            idea_ids = [idea_ids[0]]
+            print(f"\n1. Synthesizing decision for 1 idea (limit_one=True)...")
+        else:
+            print(f"\n1. Synthesizing decisions for {len(idea_ids)} ideas...")
 
         decisions = []
         for i, idea_id in enumerate(idea_ids, 1):
@@ -432,7 +442,14 @@ def run_decision_agent(dry_run=False):
             print("\n⚠️  No challenges found to synthesize")
             return []
 
-        print(f"\n2. Synthesizing decisions for {len(challenges_by_idea)} ideas...")
+        # Limit to one if requested
+        if limit_one and len(challenges_by_idea) > 1:
+            # Take only the first idea
+            first_idea_id = list(challenges_by_idea.keys())[0]
+            challenges_by_idea = {first_idea_id: challenges_by_idea[first_idea_id]}
+            print(f"\n2. Synthesizing decision for 1 idea (limit_one=True)...")
+        else:
+            print(f"\n2. Synthesizing decisions for {len(challenges_by_idea)} ideas...")
 
         decisions = []
         for i, (idea_id, challenges) in enumerate(challenges_by_idea.items(), 1):

--- a/agents/implementation/implementation.py
+++ b/agents/implementation/implementation.py
@@ -701,13 +701,14 @@ def create_pull_request(implementation):
         return None
 
 
-def run_agent(dry_run=False, use_claude=True):
+def run_agent(dry_run=False, use_claude=True, limit_one=False):
     """
     Main agent logic.
 
     Args:
         dry_run: If True, read from files and write to files instead of Kafka
         use_claude: If True, use Claude API; otherwise use fallback logic
+        limit_one: If True, only process one approved solution (for demo/interactive mode)
     """
     print("\n" + "="*80)
     print("IMPLEMENTATION AGENT - Phase 4")
@@ -728,6 +729,10 @@ def run_agent(dry_run=False, use_claude=True):
                 solution = json.load(f)
                 if solution.get("status") == "APPROVED":
                     approved_solutions.append(solution)
+
+        # Limit to one if requested
+        if limit_one and len(approved_solutions) > 1:
+            approved_solutions = [approved_solutions[0]]
 
         print(f"   Found {len(approved_solutions)} approved solution(s)")
 
@@ -750,6 +755,11 @@ def run_agent(dry_run=False, use_claude=True):
 
         # Load approved solutions from Kafka
         approved_solutions = load_approved_solutions_from_kafka()
+
+        # Limit to one if requested
+        if limit_one and len(approved_solutions) > 1:
+            approved_solutions = [approved_solutions[0]]
+
         print(f"   Found {len(approved_solutions)} approved solution(s)")
 
         if len(approved_solutions) == 0:

--- a/agents/solution/solution.py
+++ b/agents/solution/solution.py
@@ -456,13 +456,14 @@ def create_fallback_solution(idea, decision):
     }
 
 
-def run_agent(dry_run=False, use_claude=True):
+def run_agent(dry_run=False, use_claude=True, limit_one=False):
     """
     Main agent logic.
 
     Args:
         dry_run: If True, read from files and write to files instead of Kafka
         use_claude: If True, use Claude API; otherwise use fallback logic
+        limit_one: If True, only process one approved decision (for demo/interactive mode)
     """
     print("\n" + "="*80)
     print("SOLUTION AGENT - Phase 4")
@@ -483,6 +484,10 @@ def run_agent(dry_run=False, use_claude=True):
                 decision = json.load(f)
                 if decision.get("status") == "APPROVED":
                     approved_decisions.append(decision)
+
+        # Limit to one if requested
+        if limit_one and len(approved_decisions) > 1:
+            approved_decisions = [approved_decisions[0]]
 
         print(f"   Found {len(approved_decisions)} approved decision(s)")
 
@@ -510,6 +515,11 @@ def run_agent(dry_run=False, use_claude=True):
 
         # Load approved decisions from Kafka
         approved_decisions = load_approved_decisions_from_kafka()
+
+        # Limit to one if requested
+        if limit_one and len(approved_decisions) > 1:
+            approved_decisions = [approved_decisions[0]]
+
         print(f"   Found {len(approved_decisions)} approved decision(s)")
 
         if len(approved_decisions) == 0:


### PR DESCRIPTION
## Problem

During interactive demo runs, agents were processing **ALL** pending messages instead of just one. This caused the demo to run through multiple ideas, decisions, and solutions at once, breaking the intended step-by-step flow.

**Example**: If there were 4 approved decisions in Kafka, the Decision Agent would synthesize all 4 at once, then Solution Agent would design solutions for all 4, etc. This defeated the purpose of the interactive demo.

## Solution

Added `limit_one` parameter to all agents that process multiple messages. When `limit_one=True`, each agent processes only the **first** pending message.

### Agents Updated

#### 1. Decision Agent (`evaluation/decision.py`)
- Added `limit_one` parameter (default: `False`)
- When `True`, processes only first idea with complete challenges
- Works in both dry-run and Kafka modes

#### 2. Solution Agent (`solution/solution.py`)
- Added `limit_one` parameter (default: `False`)
- When `True`, processes only first approved decision
- Works in both dry-run and Kafka modes

#### 3. Implementation Agent (`implementation/implementation.py`)
- Added `limit_one` parameter (default: `False`)
- When `True`, processes only first approved solution
- Works in both dry-run and Kafka modes

#### 4. Bootstrap (`bootstrap.py`)
- Passes `limit_one=interactive` to all three agents
- **Interactive mode**: Each agent processes ONE message
- **Production mode**: Agents process ALL messages (unchanged)

## Complete Demo Flow

With this fix, the full interactive demo now flows cleanly through all 12 steps:

| Step | Agent | Behavior | Status |
|------|-------|----------|--------|
| 1-4 | Monitoring Agents | Deploy/Usage/Metrics/Current State | ✅ Already single |
| 5 | Learning Agent | Generate **1** idea | ✅ Already limited |
| 6 | Human Refinement | Approve **1** idea | ✅ Already limited (PR #18) |
| 7-9 | Evaluation Agents | Evaluate **1** idea | ✅ Already limited |
| 10 | **Decision Agent** | Synthesize **1** decision | ✅ **NEW** |
| 11 | Human Approval | Approve **1** decision | ✅ Already limited (PR #18) |
| 12 | **Solution Agent** | Design **1** solution | ✅ **NEW** |
| 13 | Human Solution Approval | Approve **1** solution | ✅ Already limited (PR #18) |
| 14 | **Implementation Agent** | Generate **1** implementation | ✅ **NEW** |

## Testing

- ✅ Interactive mode processes one message per agent
- ✅ Non-interactive mode processes all messages (unchanged)
- ✅ Standalone agent execution unaffected
- ✅ Works in both dry-run and Kafka modes

## Impact

- **Interactive demos**: Clean step-by-step flow, one idea through full pipeline
- **Production mode**: No change, still processes all pending messages
- **Backward compatible**: Default `limit_one=False` maintains existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)