### PR TITLE
fix: agents consume only one message from Kafka topics in interactive mode

### DIFF
--- a/agents/implementation/implementation.py
+++ b/agents/implementation/implementation.py
@@ -45,8 +45,12 @@ def load_solution_from_file(solution_id=None):
     return None
 
 
-def load_approved_solutions_from_kafka():
-    """Load all approved solutions from Kafka."""
+def load_approved_solutions_from_kafka(consume_one_only=False):
+    """Load approved solutions from Kafka.
+
+    Args:
+        consume_one_only: If True, only consume one message (for demos)
+    """
     print("   Loading approved solutions from Kafka...")
 
     approved_solutions = []
@@ -70,6 +74,8 @@ def load_approved_solutions_from_kafka():
             value = deserializer(msg.value(), None)
             if value and value.get("status") == "APPROVED":
                 approved_solutions.append(value)
+                if consume_one_only:
+                    break
     finally:
         consumer.close()
 
@@ -754,11 +760,7 @@ def run_agent(dry_run=False, use_claude=True, limit_one=False):
         print("☁️  KAFKA MODE: Reading from and writing to Kafka topics\n")
 
         # Load approved solutions from Kafka
-        approved_solutions = load_approved_solutions_from_kafka()
-
-        # Limit to one if requested
-        if limit_one and len(approved_solutions) > 1:
-            approved_solutions = [approved_solutions[0]]
+        approved_solutions = load_approved_solutions_from_kafka(consume_one_only=limit_one)
 
         print(f"   Found {len(approved_solutions)} approved solution(s)")
 

--- a/agents/solution/solution.py
+++ b/agents/solution/solution.py
@@ -60,8 +60,12 @@ def load_idea_from_file(idea_id):
     return None
 
 
-def load_approved_decisions_from_kafka():
-    """Load all approved decisions from Kafka."""
+def load_approved_decisions_from_kafka(consume_one_only=False):
+    """Load approved decisions from Kafka.
+
+    Args:
+        consume_one_only: If True, only consume one message (for demos)
+    """
     print("   Loading approved decisions from Kafka...")
 
     approved_decisions = []
@@ -85,6 +89,8 @@ def load_approved_decisions_from_kafka():
             value = deserializer(msg.value(), None)
             if value and value.get("status") == "APPROVED":
                 approved_decisions.append(value)
+                if consume_one_only:
+                    break
     finally:
         consumer.close()
 
@@ -514,11 +520,7 @@ def run_agent(dry_run=False, use_claude=True, limit_one=False):
         print("☁️  KAFKA MODE: Reading from and writing to Kafka topics\n")
 
         # Load approved decisions from Kafka
-        approved_decisions = load_approved_decisions_from_kafka()
-
-        # Limit to one if requested
-        if limit_one and len(approved_decisions) > 1:
-            approved_decisions = [approved_decisions[0]]
+        approved_decisions = load_approved_decisions_from_kafka(consume_one_only=limit_one)
 
         print(f"   Found {len(approved_decisions)} approved decision(s)")
 


### PR DESCRIPTION
## Problem

Agents were consuming **ALL messages** from their Kafka input topics, then filtering to one message afterwards. This caused:
- Decision Agent processed 5 decisions instead of 1 in interactive mode
- Inefficient - consuming all messages just to discard most of them
- Confusing behavior where `limit_one=True` didn't actually limit consumption

The issue was in the `while True:` polling loops - they ran until no more messages were available, collecting everything from the topic before any filtering happened.

## Solution

Added `consume_one_only` parameter to all Kafka loading functions that **breaks immediately** after consuming the first valid message:

**Decision Agent** (`load_challenges_from_kafka()`):
- Consumes one scope challenge, one time challenge, one cost challenge
- Breaks after first message per topic when `consume_one_only=True`

**Solution Agent** (`load_approved_decisions_from_kafka()`):
- Consumes one approved decision
- Breaks immediately after first APPROVED decision

**Implementation Agent** (`load_approved_solutions_from_kafka()`):
- Consumes one approved solution  
- Breaks immediately after first APPROVED solution

All agents pass `consume_one_only=limit_one` to ensure consumption behavior matches processing intent.

## Changes

- ✅ `agents/evaluation/decision.py`: Add `consume_one_only` param, break after first message per topic
- ✅ `agents/solution/solution.py`: Add `consume_one_only` param, remove redundant post-filtering
- ✅ `agents/implementation/implementation.py`: Add `consume_one_only` param, remove redundant post-filtering

## Impact

- **Interactive mode**: Agents now truly consume and process ONE message
- **Production mode**: Agents still consume all messages when `limit_one=False`
- **Efficiency**: No wasted Kafka consumption bandwidth in demos
- **Correctness**: Behavior matches user expectations

## Testing

Tested with bootstrap in interactive mode - agents now process exactly one message as expected.

## Related

- Complements PR #20 (which added `limit_one` parameter)
- This PR fixes the actual consumption layer that PR #20 missed
- Supersedes the post-consumption filtering logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)