### PR TITLE
feat: add --limit-one flag to implementation agent CLI

### DIFF
--- a/agents/implementation/implementation.py
+++ b/agents/implementation/implementation.py
@@ -904,11 +904,16 @@ def main():
         action="store_true",
         help="Use fallback logic instead of Claude API"
     )
+    parser.add_argument(
+        "--limit-one",
+        action="store_true",
+        help="Process only one approved solution (useful for testing)"
+    )
 
     args = parser.parse_args()
 
     try:
-        run_agent(dry_run=args.dry_run, use_claude=not args.no_claude)
+        run_agent(dry_run=args.dry_run, use_claude=not args.no_claude, limit_one=args.limit_one)
     except KeyboardInterrupt:
         print("\n\n⚠️  Agent interrupted by user")
         sys.exit(1)


### PR DESCRIPTION
## Summary

Adds a `--limit-one` command-line flag to the implementation agent to process only one approved solution at a time.

## What's Added

- `--limit-one` CLI argument that limits processing to a single approved solution
- Useful for testing and demonstrations
- Already supported internally via bootstrap.py, now exposed via CLI

## Usage

```bash
# Process one solution from Kafka
python agents/implementation/implementation.py --limit-one

# Process one solution from dry-run files
python agents/implementation/implementation.py --dry-run --limit-one
```

## Why This Matters

This flag is essential for:
- **Testing**: Verify PR creation works without processing all solutions
- **Demos**: Show the agent flow one solution at a time
- **Safety**: Prevent creating multiple PRs when testing fixes

Previously, this functionality was only available when running through `bootstrap.py --interactive`.